### PR TITLE
Fix incorrect raw flag

### DIFF
--- a/lib/zebra/print_job.rb
+++ b/lib/zebra/print_job.rb
@@ -29,7 +29,7 @@ module Zebra
 
     def send_to_printer(path)
       puts "* * * * * * * * * * * * Sending file to printer #{@printer} at #{@remote_ip} * * * * * * * * * * "
-      result = system("rlpr -H #{@remote_ip} -P #{@printer} -o raw #{path} 2>&1") # try printing to LPD on windows machine first
+      result = system("rlpr -H #{@remote_ip} -P #{@printer} -o #{path} 2>&1") # try printing to LPD on windows machine first
       system("lp -h #{@remote_ip} -d #{@printer} -o raw #{path}") if !result # print to unix (CUPS) if rlpr failed
     end
   end


### PR DESCRIPTION
The `-o raw` option flag is necessary for plan 'ol `lp`.

Howeveah, for `rlpr` the `-o` flag itself means raw format.  From the [man page](http://manpages.ubuntu.com/manpages/trusty/man1/rlpr.1.html):
> -o   Assume data is postscript.

Using `-o raw` on `rlpr` isn't totally detrimental (the command still executes), but it will throw you a `rlpr: error: skipping file 'raw': No such file or directory`