### PR TITLE
Support QR codes (fixed)

### DIFF
--- a/lib/zebra/zpl/qrcode.rb
+++ b/lib/zebra/zpl/qrcode.rb
@@ -10,6 +10,10 @@ module Zebra
 
       attr_reader :scale_factor, :correction_level
 
+      def width=(width)
+        @width = width || 0
+      end
+
       def scale_factor=(value)
         raise InvalidScaleFactorError unless (1..99).include?(value.to_i)
         @scale_factor = value

--- a/lib/zebra/zpl/qrcode.rb
+++ b/lib/zebra/zpl/qrcode.rb
@@ -26,7 +26,7 @@ module Zebra
 
       def to_zpl
         check_attributes
-        ["b#{x}", y, "Q", "s#{scale_factor}", "e#{correction_level}", "\"#{data}\""].join(",")
+        "^FW#{rotation}^FO#{x},#{y}^BQN,2,#{scale_factor},,3^FD#{correction_level}A,#{data}^FS"
       end
 
       private


### PR DESCRIPTION
Running the example snippet from the README would result in:
```
NoMethodError: undefined method `width=' for #<Zebra::Zpl::Qrcode:0x007fb0cf377cd8>
```
I added a `width=` assignment method to the `Qrcode` module to correct this.

Also, the ZPL command for producing the QR code seemed off as well. I have updated it to adhere to the command definition found in the [ZPL docs (pg. 102)](https://www.zebra.com/content/dam/zebra/manuals/en-us/software/zplii-pm-vol1.pdf#page=102)

Now running the example snippet will produce the following:

```zpl
^XA^LL250^LH0,0^LS10^PW350^PR3^FWN^FO50,10^BQN,2,6,,3^FDHA,www.github.com^FS^PQ1^XZ
```

<img src="https://i.imgur.com/QDEcz23.png"/>