### PR TITLE
update label print density range from 0-6 to 0-15

### DIFF
--- a/lib/zebra/zpl/label.rb
+++ b/lib/zebra/zpl/label.rb
@@ -27,7 +27,7 @@ module Zebra
       end
 
       def print_density=(d)
-        raise InvalidPrintDensityError unless (0..6).include?(d)
+        raise InvalidPrintDensityError unless (0..15).include?(d)
         @print_density = d
       end
 


### PR DESCRIPTION
The ReadMe specifies a density range of 0-15 but for some reason a range of 0-6 is enforced in the code.  The range should be expanded allow for higher densities like 12 (300dpi) and to properly match the documentation.