### PR TITLE
Remove the hardcoded attributes for the box element

### DIFF
--- a/lib/zebra/zpl/box.rb
+++ b/lib/zebra/zpl/box.rb
@@ -5,9 +5,11 @@ module Zebra
     class Box
       include Printable
 
-      class InvalidLineThickness < StandardError; end
+      class InvalidLineThickness  < StandardError; end
+      class InvalidRoundingDegree < StandardError; end
+      class InvalidColorError     < StandardError; end
 
-      attr_reader :line_thickness, :box_width, :box_height, :width
+      attr_reader :line_thickness, :box_width, :box_height, :width, :color, :rounding_degree
 
       def line_thickness=(thickness)
         raise InvalidLineThickness unless thickness.nil? || thickness.to_i.to_s == thickness.to_s
@@ -27,10 +29,19 @@ module Zebra
         @box_height = height
       end
 
+      def rounding_degree=(value)
+        raise InvalidLineThickness unless value.to_i.in? (0..8)
+        @rounding_degree = value
+      end
+
+      def color=(value)
+        raise InvalidColorError unless value.upcase.in?(["W","B"])
+        @color = value
+      end
+
       def to_zpl
         check_attributes
-        # "^FO#{x},#{y}^GB#{box_width},#{box_height},#{line_thickness}^FS"
-        "^FO#{x},#{y}^GB#{box_width},#{box_height},#{line_thickness}^FS"
+        "^FO#{x},#{y}^GB#{box_width},#{box_height},#{line_thickness},#{color},#{rounding_degree}^FS"
       end
 
       private


### PR DESCRIPTION
Related to issue #30. This PR adds the corner rounding (values 0 to 8) and color attribute to the already existing box element.

```
label = Zebra::Zpl::Label.new(
    :width         => 800,
    :length        => 800,
    :print_speed   => 6,
    :print_density => 5,
    :copies        => 1
)

label_box_test1 = Zebra::Zpl::Box.new :position => [0, 140], :rounding_degree => 3, :line_thickness => 20, box_width: 200, box_height: 200, :color => "G"

label << label_box_test1
label.dump_contents
>>^XA^LL800^LH0,0^LS10^PW800^PR6^FO0,140^GB200,200,20,B,3^FS^PQ1^XZ
```

<img width="125" alt="screen shot 2018-10-28 at 9 31 08 pm" src="https://user-images.githubusercontent.com/16580125/47625325-c7965f00-dafa-11e8-923e-7126a05a6e3d.png">
