### PR TITLE
Fix height bug with ^B commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.1.0 (next)
 
 * Your contribution here.
+* [#54](https://github.com/bbulpett/zebra-zpl/pull/54): Fix height bug with ^B commands - [@mtking2](https://github.com/mtking2)
 * [#53](https://github.com/bbulpett/zebra-zpl/pull/53): Added support for symbol types, fixed other bugs with the `Graphic` class, updated specs - [@mtking2](https://github.com/mtking2)
 * [#50](https://github.com/bbulpett/zebra-zpl/pull/50): Add support for image elements by incorporating the [img2zpl](https://github.com/mtking2/img2zpl) gem - [@mtking2](https://github.com/mtking2)
 * [#49](https://github.com/bbulpett/zebra-zpl/pull/49): Fixed bug with `Barcode`'s `^BY` command. Added UPCA, UPCE, & EAN13 types - [@mtking2](https://github.com/mtking2)

--- a/lib/zebra/zpl/datamatrix.rb
+++ b/lib/zebra/zpl/datamatrix.rb
@@ -62,7 +62,7 @@ module Zebra
 
       def to_zpl
         check_attributes
-        "^FW#{rotation}^FO#{x},#{y}^BX#{orientation},#{symbol_height},#{quality},#{columns},#{rows},#{format},#{escape_sequence},#{aspect_ratio}^FD#{data}^FS"
+        "^FW#{rotation}^FO#{x},#{y}^BY,,10^BX#{orientation},#{symbol_height},#{quality},#{columns},#{rows},#{format},#{escape_sequence},#{aspect_ratio}^FD#{data}^FS"
       end
 
       private

--- a/lib/zebra/zpl/pdf417.rb
+++ b/lib/zebra/zpl/pdf417.rb
@@ -36,7 +36,7 @@ module Zebra
 
       def to_zpl
         check_attributes
-        "^FO#{x},#{y}^B7#{rotation},#{row_height},#{security_level},#{column_number},#{row_number},#{truncate} ^FD #{data} ^FS"
+        "^FO#{x},#{y}^BY,,10^B7#{rotation},#{row_height},#{security_level},#{column_number},#{row_number},#{truncate} ^FD #{data} ^FS"
       end
 
       private

--- a/lib/zebra/zpl/qrcode.rb
+++ b/lib/zebra/zpl/qrcode.rb
@@ -26,7 +26,7 @@ module Zebra
 
       def to_zpl
         check_attributes
-        "^FW#{rotation}^FO#{x},#{y}^BQN,2,#{scale_factor},,3^FD#{correction_level}A,#{data}^FS"
+        "^FW#{rotation}^FO#{x},#{y}^BY,,10^BQN,2,#{scale_factor},,3^FD#{correction_level}A,#{data}^FS"
       end
 
       private

--- a/spec/zebra/zpl/datamatrix_spec.rb
+++ b/spec/zebra/zpl/datamatrix_spec.rb
@@ -106,19 +106,19 @@ describe Zebra::Zpl::Datamatrix do
       end
 
       it "contains Data Matrix code type" do
-        expect(tokens[4]).to eq "^BXN"
+        expect(tokens[6]).to eq "^BXN"
       end
 
       it "contains the symbol_height" do
-        expect(tokens[5]).to eq "5"
+        expect(tokens[7]).to eq "5"
       end
 
       it "contains the quality level" do
-        expect(tokens[6]).to eq "200"
+        expect(tokens[8]).to eq "200"
       end
 
       it "contains the data to be printed in the datamatrix" do
-        expect(tokens[8]).to eq "foobar"
+        expect(tokens[10]).to eq "foobar"
       end
   end
 end

--- a/spec/zebra/zpl/pdf417_spec.rb
+++ b/spec/zebra/zpl/pdf417_spec.rb
@@ -82,27 +82,27 @@ describe Zebra::Zpl::PDF417 do
       end
 
       it "contains the row height" do
-        expect(tokens[2]).to eq "5"
+        expect(tokens[4]).to eq "5"
       end
 
       it "contains the security level" do
-        expect(tokens[3]).to eq "5"
+        expect(tokens[5]).to eq "5"
       end
 
       it "contains the column number" do
-        expect(tokens[4]).to eq "15"
+        expect(tokens[6]).to eq "15"
       end
 
       it "contains the row number" do
-        expect(tokens[5]).to eq "30"
+        expect(tokens[7]).to eq "30"
       end
 
       it "contains the trucate option" do
-        expect(tokens[6].match(/(\w) \^/)[1]).to eq "N"
+        expect(tokens[8].match(/(\w) \^/)[1]).to eq "N"
       end
 
       it "contains the data to be printed in the pdf417 barcode" do
-        expect(tokens[6].include?("Do away with it!")).to eq true
+        expect(tokens[8].include?("Do away with it!")).to eq true
       end
   end
 end

--- a/spec/zebra/zpl/qrcode_spec.rb
+++ b/spec/zebra/zpl/qrcode_spec.rb
@@ -83,19 +83,19 @@ describe Zebra::Zpl::Qrcode do
     end
 
     it "contains QR code type" do
-      expect(tokens[4]).to eq "^BQN"
+      expect(tokens[6]).to eq "^BQN"
     end
 
     it "contains the scale factor" do
-      expect(tokens[6]).to eq "3"
+      expect(tokens[8]).to eq "3"
     end
 
     it "contains the error correction level" do
-      expect(tokens[7]).to eq "3"
+      expect(tokens[9]).to eq "3"
     end
 
     it "contains the data to be printed in the qrcode" do
-      expect(tokens[9]).to eq "foobar"
+      expect(tokens[11]).to eq "foobar"
     end
   end
 end


### PR DESCRIPTION
Any `^B` command will default to the last used `width`, `height`, and `ratio` set by the last `^BY` command. 

This would cause some unexpected height issues whenever a `Barcode` was used before either a `Qrcode`, `PDF417`, or `Datamatrix`, causing the later to inherit the height of the last proceeding `Barcode`.