### PR TITLE
Release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### 1.1.1 (next)
 
 * Your contribution here.
+
+### 1.1.1 (12/19/2019)
+
 * [#58](https://github.com/bbulpett/zebra-zpl/pull/58): Add access to source `Img2Zpl::Image` object - [@mtking2](https://github.com/mtking2)
 
 ### 1.1.0 (11/04/2019)


### PR DESCRIPTION
Wrapping up version 1.1.1. It should be up on RubyGems (https://rubygems.org/gems/zebra-zpl) soon.