### PR TITLE
Un-restrict Font Size

### DIFF
--- a/lib/zebra/zpl/font.rb
+++ b/lib/zebra/zpl/font.rb
@@ -15,7 +15,7 @@ module Zebra
       SIZE_9 = 133 # 48pt
 
       def self.valid_font_size?(font_size)
-        [12, 17, 22, 28, 33, 44, 67, 100, 111, 133].include?(font_size.to_i)
+        (0..32000).include?(font_size.to_i)
       end
 
       def self.validate_font_size(font_size)

--- a/spec/zebra/zpl/text_spec.rb
+++ b/spec/zebra/zpl/text_spec.rb
@@ -56,7 +56,10 @@ describe Zebra::Zpl::Text do
   describe "#font_size=" do
     it "raises an error if the received font_size is invalid" do
       expect {
-        described_class.new.font_size = 6
+        described_class.new.font_size = -1
+      }.to raise_error(Zebra::Zpl::FontSize::InvalidFontSizeError)
+      expect {
+        described_class.new.font_size = 32001
       }.to raise_error(Zebra::Zpl::FontSize::InvalidFontSizeError)
     end
   end


### PR DESCRIPTION
Allow font sizes between 0 and 32000 dots.

Resolves #61