### PR TITLE
Fix mistakes in Text node printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,8 @@ You create text elements to print using instances of the `Zebra::Zpl::Text` clas
 * `position`: An array with the coordinates to place the text, in dots.
 * `rotation`: The rotation for the text. More about the possible values below (see [Rotation](#elements-rotation) section).
 * `data`: The text to be printed.
-* `print_mode`: The print mode. Can be normal ("N") or reverse ("R").
 * `font_size`: The font size to use. You can use values between 1 and 5.
-
-For the print modes, you can also use the constants:
-
-* `Zebra::Zpl::PrintMode::NORMAL`
-* `Zebra::Zpl::PrintMode::REVERSE`
+* `reverse_print`: Allows a field to appear as white over black or black over white
 
 ### Raw ZPL
 

--- a/lib/zebra/zpl/label.rb
+++ b/lib/zebra/zpl/label.rb
@@ -4,7 +4,6 @@ module Zebra
   module Zpl
     class Label
       class InvalidPrintSpeedError     < StandardError; end
-      class InvalidPrintDensityError   < StandardError; end
       class PrintSpeedNotInformedError < StandardError; end
 
       attr_writer :copies

--- a/lib/zebra/zpl/text.rb
+++ b/lib/zebra/zpl/text.rb
@@ -8,6 +8,7 @@ module Zebra
       class InvalidMaxLinesError < StandardError; end
 
       attr_reader :font_size, :font_type, :width, :line_spacing, :hanging_indent, :bold
+      attr_writer :reverse_print
 
       def font_size=(f)
         FontSize.validate_font_size f
@@ -19,16 +20,20 @@ module Zebra
       end
 
       def width=(width)
-        unless (margin.nil? || margin < 1)
-          @width = (width - (margin*2))
-        else
+        if (margin.nil? || margin < 1)
           @width = width || 0
+        else
+          @width = (width - (margin*2))
         end
       end
 
       def max_lines=(value)
         raise InvalidMaxLinesError unless value.to_i >= 1
         @max_lines = value
+      end
+
+      def max_lines
+        @max_lines || 4
       end
 
       def line_spacing=(value)
@@ -48,48 +53,17 @@ module Zebra
         @font_type || FontType::TYPE_0
       end
 
-      def print_mode=(mode)
-        PrintMode.validate_mode mode
-        @print_mode = mode
+      def reverse_print
+        @reverse_print || false
       end
-
-      def print_mode
-        @print_mode || PrintMode::NORMAL
-      end
-
-      # def h_multiplier
-      #   @h_multiplier || HorizontalMultiplier::VALUE_1
-      # end
-      #
-      # def v_multiplier
-      #   @v_multiplier || VerticalMultiplier::VALUE_1
-      # end
-
-      def print_mode
-        @print_mode || PrintMode::NORMAL
-      end
-
-      def max_lines
-        @max_lines || 4
-      end
-
-      # def h_multiplier=(multiplier)
-      #   HorizontalMultiplier.validate_multiplier multiplier
-      #   @h_multiplier = multiplier
-      # end
-      #
-      # def v_multiplier=(multiplier)
-      #   VerticalMultiplier.validate_multiplier multiplier
-      #   @v_multiplier = multiplier
-      # end
 
       def to_zpl
         check_attributes
         if !bold.nil?
-          "^FW#{rotation}^CF#{font_type},#{font_size}^CI28^FO#{x+2},#{y}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}^FD#{data}^FS" +
-          "^FW#{rotation}^CF#{font_type},#{font_size}^CI28^FO#{x},#{y+2}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}^FD#{data}^FS"
+          "^FW#{rotation}^A#{font_type},#{font_size}^CI28^FO#{x+2},#{y}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}#{appear_in_reverse}^FD#{data}^FS" +
+          "^FW#{rotation}^A#{font_type},#{font_size}^CI28^FO#{x},#{y+2}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}#{appear_in_reverse}^FD#{data}^FS"
         else
-          "^FW#{rotation}^CF#{font_type},#{font_size}^CI28^FO#{x},#{y}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}^FD#{data}^FS"
+          "^FW#{rotation}^A#{font_type},#{font_size}^CI28^FO#{x},#{y}^FB#{width},#{max_lines},#{line_spacing},#{justification},#{hanging_indent}#{appear_in_reverse}^FD#{data}^FS"
         end
       end
 
@@ -98,6 +72,10 @@ module Zebra
       def check_attributes
         super
         raise MissingAttributeError.new("the font_size to be used is not given") unless @font_size
+      end
+
+      def appear_in_reverse
+        reverse_print ? '^FR' : ''
       end
     end
   end

--- a/spec/zebra/zpl/text_spec.rb
+++ b/spec/zebra/zpl/text_spec.rb
@@ -21,28 +21,15 @@ describe Zebra::Zpl::Text do
     expect(text.font_size).to eq font_size
   end
 
-  # it "can be initialized with the horizontal multiplier" do
-  #   multiplier = Zebra::Zpl::HorizontalMultiplier::VALUE_1
-  #   text = described_class.new h_multiplier: multiplier
-  #   expect(text.h_multiplier).to eq multiplier
-  # end
-  #
-  # it "can be initialized with the vertical multiplier" do
-  #   multiplier = Zebra::Zpl::VerticalMultiplier::VALUE_1
-  #   text = described_class.new v_multiplier: multiplier
-  #   expect(text.v_multiplier).to eq multiplier
-  # end
-
   it "can be initialized with the data to be printed" do
     data = "foobar"
     text = described_class.new data: data
     expect(text.data).to eq data
   end
 
-  it "can be initialized with the printing mode" do
-    print_mode = Zebra::Zpl::PrintMode::REVERSE
-    text = described_class.new print_mode: print_mode
-    expect(text.print_mode).to eq print_mode
+  it "can be initialized with the reverse_print" do
+    text = described_class.new reverse_print: true
+    expect(text.reverse_print).to eq true
   end
 
   describe "#rotation=" do
@@ -61,30 +48,6 @@ describe Zebra::Zpl::Text do
       expect {
         described_class.new.font_size = 32001
       }.to raise_error(Zebra::Zpl::FontSize::InvalidFontSizeError)
-    end
-  end
-
-  # describe "#h_multiplier=" do
-  #   it "raises an error if the received multiplier is invalid" do
-  #     expect {
-  #       described_class.new.h_multiplier = 9
-  #     }.to raise_error(Zebra::Zpl::HorizontalMultiplier::InvalidMultiplierError)
-  #   end
-  # end
-  #
-  # describe "#v_multiplier=" do
-  #   it "raises an error if the received multiplier is invalid" do
-  #     expect {
-  #       described_class.new.v_multiplier = 10
-  #     }.to raise_error(Zebra::Zpl::VerticalMultiplier::InvalidMultiplierError)
-  #   end
-  # end
-
-  describe "#print_mode=" do
-    it "raises an error if the received print mode is invalid" do
-      expect {
-        described_class.new.print_mode = "foo"
-      }.to raise_error(Zebra::Zpl::PrintMode::InvalidPrintModeError)
     end
   end
 
@@ -126,19 +89,21 @@ describe Zebra::Zpl::Text do
     end
 
     it "contains the attributes in correct order" do
-      expect(text.to_zpl).to eq '^FWN^CF0,28^CI28^FO100,150^FB,4,,L,^FDfoobar^FS'
+      expect(text.to_zpl).to eq '^FWN^A0,28^CI28^FO100,150^FB,4,,L,^FDfoobar^FS'
     end
 
     it "contains the properly duplicated attributes in correct order for bold text" do
-      expect(text_bold.to_zpl).to eq '^FWN^CF0,28^CI28^FO102,150^FB,4,,L,^FDfoobar^FS^FWN^CF0,28^CI28^FO100,152^FB,4,,L,^FDfoobar^FS'
+      expect(text_bold.to_zpl).to eq '^FWN^A0,28^CI28^FO102,150^FB,4,,L,^FDfoobar^FS^FWN^A0,28^CI28^FO100,152^FB,4,,L,^FDfoobar^FS'
     end
 
-    # it "assumes 1 as the default horizontal multipler" do
-    #   expect(text.to_zpl.split(",")[4].to_i).to eq Zebra::Zpl::HorizontalMultiplier::VALUE_1
-    # end
-    #
-    # it "assumes 1 as the default vertical multiplier" do
-    #   expect(text.to_zpl.split(",")[5].to_i).to eq Zebra::Zpl::VerticalMultiplier::VALUE_1
-    # end
+    it 'contains reverse print field on reverse_print mode' do
+      text = described_class.new position: [100, 100], font_size: Zebra::Zpl::FontSize::SIZE_3, data: "foobar", reverse_print: true
+
+      expect(text.to_zpl).to match /\^FR/
+    end
+
+    it 'does not have reverse print field if not specified' do
+      expect(text.to_zpl).to_not match /\^FR/
+    end
   end
 end


### PR DESCRIPTION
In the scope of this PR we do next:

1. Add `reverse_print` setting for `Zpl::Text` node.
2. Fix mistake with redefining of the default font.
3. Removed un-used method from `Zpl::Text`

## In Details:
## Reverse print:
`reverse_print` adds `^FR` tag to the field.

^FR - Field Reverse Print

The ^FR command allows a field to appear as white over black or black over white. When printing a field
and the ^FR command has been used, the color of the output is the reverse of its background.

Example:
```
^XA
^FO100,100^GB200,120,120^FS
^FO110,110^FR^AC^FDThe first line^FS
^FO110,150^FR^AC^FDThe second line^FS
^XZ
```

<img width="775" alt="Screenshot_2021-11-06_at_10_05_13_and_Screenshot_2021-11-06_at_10_05_03_and_Screenshot_2021-11-06_at_10_22_59_and__WIP__Fix_mistakes_in_Text_node_printing_by_DmytroVasin_·_Pull_Request__77_·_bbulpett_zebra-zpl" src="https://user-images.githubusercontent.com/1914001/140603266-916c145d-7856-4065-9a3f-10751f1ab470.png">

### Redefining of the default font.
Currently, in `Zpl::Text` node we use tag `^CF#{font_type},#{font_size}`.

`^CF` -> Changes Alphanumeric **Default** Font.

I do not think that is correct to change the default font in the scope of one Tag.
So I redefined it to `^A#{font_type},#{font_size}`.

> The ^A command specifies the font to use in a text field. ^A designates the font for the current ^FD
> statement or field. The font specified by ^A is used only once for that ^FD entry. If a value for ^A is not
> specified again, the default ^CF font is used for the next ^FD entry.

Examples:
```
^XA

^CFA,15

^AG,15^FO50,300^FDJohn Doe^FS
^FO50,340^FD100 Main Street^FS
^FO50,380^FDSpringfield TN 39021^FS
^FO50,420^FDUnited States (USA)^FS

^CFA,15
^FO638,340^FDPermit^FS
^FO638,390^FD123456^FS
^FO50,500^GB700,3,3^FS

^XZ
```
<img width="1003" alt="Screenshot_2021-11-06_at_10_22_59_and_Screenshot_2021-11-06_at_10_22_28" src="https://user-images.githubusercontent.com/1914001/140603245-61dc80b0-e7b0-49d0-ba41-c3f2101046c5.png">

## Removed un-used code:

`print_mode` in `Zpl::Text` was not used at all - so I removed get/set methods. Also, I removed it from docs. 


## Docs link:
https://www.zebra.com/content/dam/zebra/manuals/printers/common/programming/zpl-zbi2-pm-en.pdf