### PR TITLE
Improvements to barcode usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ You create barcode elements to print using instances of the `Zebra::Zpl::Barcode
 * `type`: The type os barcode to use. More on the available types below.
 * `narrow_bar_width`: The barcode's narrow bar width, in dots.
 * `wide_bar_width`: The barcode's wide bar width, in dots.
-* `print_human_readable_code`: Can be `true` or `false`, indicates if the human readable contents should be printed below the barcode.
+* `print_human_readable_code`: Can be `true` or `false`, indicates if the human readable contents should/should not be printed. Default: `false`.
+* `print_text_above`: Can be `true` or `false`, indicates if the human readable contents should be printed above/below the barcode. Default: `false`.
+* `mode`: Can be `N/U/A/D`. Mode value which is optional for `Code 128 Bar Code: CODE_128_AUTO`.
 
 The available barcode types are:
 
@@ -196,6 +198,10 @@ The available barcode types are:
 * `Zebra::Zpl::BarcodeType::CODE_AZTEC_PARAMS`
 * `Zebra::Zpl::BarcodeType::CODE_UPS_MAXICODE`
 * `Zebra::Zpl::BarcodeType::CODE_QR`
+* `Zebra::Zpl::BarcodeType::CODE_UPCA`
+* `Zebra::Zpl::BarcodeType::CODE_UPCE`
+* `Zebra::Zpl::BarcodeType::CODE_EAN8`
+* `Zebra::Zpl::BarcodeType::CODE_EAN13`
 
 ### QR Codes
 

--- a/lib/zebra/zpl/barcode_type.rb
+++ b/lib/zebra/zpl/barcode_type.rb
@@ -13,6 +13,7 @@ module Zebra
       CODE_QR             = "Q"
       CODE_UPCA           = "U"
       CODE_UPCE           = "9"
+      CODE_EAN8           = "8"
       CODE_EAN13          = "E"
 
       # Legacy (EPL) bar code suffixes
@@ -26,7 +27,7 @@ module Zebra
       # CODABAR             = "K"
 
       def self.valid_barcode_type?(type)
-        %w(3 A C K 0 O D Q U 9 E).include? type
+        %w(3 A C K 0 O D Q U 9 8 E).include? type
       end
 
       def self.validate_barcode_type(type)

--- a/lib/zebra/zpl/graphic.rb
+++ b/lib/zebra/zpl/graphic.rb
@@ -61,19 +61,21 @@ module Zebra
       def to_zpl
         check_attributes
         graphic = case graphic_type
-        when "B"
-          "B#{graphic_width},#{graphic_height},#{line_thickness},#{color},#{rounding_degree}"
-        when "C"
-          "C#{graphic_width},#{line_thickness},#{color}"
-        when "D"
-          "D#{graphic_width},#{graphic_height},#{line_thickness},#{color},#{orientation}"
-        when "E"
-          "E#{graphic_width},#{graphic_height},#{line_thickness},#{color}"
-        when "S"
+        when BOX
+          "^GB#{graphic_width},#{graphic_height},#{line_thickness},#{color},#{rounding_degree}"
+        when CIRCLE
+          "^GC#{graphic_width},#{line_thickness},#{color}"
+        when DIAGONAL
+          "^GD#{graphic_width},#{graphic_height},#{line_thickness},#{color},#{orientation}"
+        when ELLIPSE
+          "^GE#{graphic_width},#{graphic_height},#{line_thickness},#{color}"
+        when SYMBOL
           sym = !symbol_type.nil? ? "^FD#{symbol_type}" : ''
-          "S,#{graphic_height},#{graphic_width}#{sym}"
+          "^GS,#{graphic_height},#{graphic_width}#{sym}"
+        else
+          raise InvalidGraphicType
         end
-        "^FW#{rotation}^FO#{x},#{y}^G#{graphic}^FS"
+        "^FW#{rotation}^FO#{x},#{y}#{graphic}^FS"
       end
 
       private

--- a/spec/zebra/zpl/barcode_spec.rb
+++ b/spec/zebra/zpl/barcode_spec.rb
@@ -56,6 +56,16 @@ describe Zebra::Zpl::Barcode do
     expect(barcode.print_human_readable_code).to eq true
   end
 
+  it "can be initialized informing if the human readable code should be printed above" do
+    barcode = described_class.new print_text_above: true
+    expect(barcode.print_text_above).to eq true
+  end
+
+  it "can be initialized with the barcode mode" do
+    barcode = described_class.new mode: 'U'
+    expect(barcode.mode).to eq 'U'
+  end
+
   describe "#rotation=" do
     it "raises an error if the received rotation is invalid" do
       expect {
@@ -91,6 +101,12 @@ describe Zebra::Zpl::Barcode do
   describe "#print_human_readable_code" do
     it "defaults to false" do
       expect(described_class.new.print_human_readable_code).to eq false
+    end
+  end
+
+  describe "#print_text_above" do
+    it "defaults to false" do
+      expect(described_class.new.print_text_above).to eq false
     end
   end
 
@@ -196,8 +212,59 @@ describe Zebra::Zpl::Barcode do
       expect(tokens[9]).to eq 'N'
     end
 
+    it "contains the correct indication when the human readable code should be printed above or below" do
+      valid_attributes.merge! print_text_above: true
+      expect(tokens[10]).to eq 'Y'
+    end
+
+    it "contains the correct indication when the human readable code should not be printed above or below" do
+      valid_attributes.merge! print_text_above: false
+      expect(tokens[10]).to eq 'N'
+    end
+
+    it "contains the correct indication of a mode in barcode" do
+      valid_attributes.merge! mode: 'U'
+      expect(tokens[11]).to eq 'U'
+    end
+
     it "contains the data to be printed in the barcode" do
-      expect(tokens[11]).to eq 'foobar'
+      expect(tokens[12]).to eq 'foobar'
+    end
+  end
+
+  describe "#to_zpl with CODE_39" do
+    let(:valid_attributes) { {
+      position:         [100, 150],
+      type:             Zebra::Zpl::BarcodeType::CODE_39,
+      height:           20,
+      width:            5,
+      narrow_bar_width: 3,
+      wide_bar_width:   6,
+      print_human_readable_code: true,
+      print_text_above: true,
+      data:             "foobar"
+    } }
+    let(:barcode) { described_class.new valid_attributes }
+
+    it "contains the barcode type" do
+      expect(barcode.to_zpl).to end_with "^B#{Zebra::Zpl::BarcodeType::CODE_39}N,,,Y,Y^FDfoobar^FS"
+    end
+  end
+
+  describe "#to_zpl with CODE_UPS_MAXICODE" do
+    let(:valid_attributes) { {
+      position:         [100, 150],
+      type:             Zebra::Zpl::BarcodeType::CODE_UPS_MAXICODE,
+      height:           20,
+      width:            5,
+      narrow_bar_width: 3,
+      wide_bar_width:   6,
+      data:             "foobar"
+    } }
+    let(:barcode) { described_class.new valid_attributes }
+
+    it "contains the barcode type" do
+      expect(barcode.to_zpl).to end_with "^B#{Zebra::Zpl::BarcodeType::CODE_UPS_MAXICODE}^FDfoobar^FS"
     end
   end
 end


### PR DESCRIPTION
In the scope of this PR I've did 3 improvements:

1. Improved usage of barcodes
2. Add new barcode: `CODE_EAN8`
3. Add setter to `print_text_above` which is used in barcode definitions.
4. Add an accessor for `mode` which is used only in `CODE_128_AUTO`

## In details:

This PR resolves the issue described in the scope of https://github.com/bbulpett/zebra-zpl/issues/76

In the current version of `zebra-zpl` we have a bug, related to incorrect parameters that is set for some Barcodes.
You can read in detail about such an example in https://github.com/bbulpett/zebra-zpl/issues/76, but the current situation is happening with almost all barcodes.

## P.S.
NOTE: When I wrote the code I followed the concept that I found in `Zpl::Graphic` class.
