### PR TITLE
Label shift attribute and D font type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.1.4 (next)
 
-* Your contribution here.
+* Added D font type - [@vkhalzov](https://github.com/vkhalzov)
+* Added `label_shift` configurable attribute - [@vkhalzov](https://github.com/vkhalzov)
 
 ### 1.1.3 (10/05/2020)
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You create new labels with an instance of the `Zebra::Zpl::Label` class. It acce
 * `width`: The label's width, in dots.
 * `length`: The label's length, is dots.
 * `print_speed`: The print speed to be used. You can use values between 0 and 6. This option is required.
+* `label_shift`: The label's shift is used to shift all field positions to the left. This option defaults to 10.
 
 With a label, you can start adding elements to it:
 

--- a/lib/zebra/zpl/font.rb
+++ b/lib/zebra/zpl/font.rb
@@ -30,13 +30,14 @@ module Zebra
       TYPE_CD = "CD" # 6pt
       TYPE_A  = "A" # 6pt
       TYPE_B  = "B" # 6pt
+      TYPE_D  = "D" # 6pt
       TYPE_E  = "E" # 6pt
       TYPE_F  = "F" # 6pt
       TYPE_G  = "G" # 6pt
       TYPE_H  = "H" # 6pt
 
       def self.valid_font_type?(font_type)
-        ["0", "CD", "A", "B", "E", "F", "G", "H"].include?(font_type)
+        ["0", "CD", "A", "B", "D", "E", "F", "G", "H"].include?(font_type)
       end
 
       def self.validate_font_type(font_type)

--- a/lib/zebra/zpl/label.rb
+++ b/lib/zebra/zpl/label.rb
@@ -7,7 +7,7 @@ module Zebra
       class InvalidPrintDensityError   < StandardError; end
       class PrintSpeedNotInformedError < StandardError; end
 
-      attr_writer :copies
+      attr_writer :copies, :label_shift
       attr_reader :elements, :tempfile
       attr_accessor :width, :length, :print_speed
 
@@ -25,6 +25,10 @@ module Zebra
         @copies || 1
       end
 
+      def label_shift
+        @label_shift || 10
+      end
+
       def <<(element)
         element.width = self.width if element.respond_to?("width=") && element.width.nil?
         elements << element
@@ -40,7 +44,7 @@ module Zebra
         # ^LH<label home - x,y coordinates of top left label>
         io << "^LH0,0"
         # ^LS<shift the label to the left(or right)>
-        io << "^LS10"
+        io << "^LS#{label_shift}"
         # ^PW<label width in dots>
         io << "^PW#{width}" if width
         # Print Rate(speed) (^PR command)

--- a/spec/zebra/zpl/label_spec.rb
+++ b/spec/zebra/zpl/label_spec.rb
@@ -6,29 +6,13 @@ describe Zebra::Zpl::Label do
   subject(:label) { described_class.new print_speed: 2 }
 
   describe "#new" do
-    it "sets the label width" do
-      label = described_class.new width: 300
-      expect(label.width).to eq 300
+    it "sets default values" do
+      expect(described_class.new).to have_attributes({ label_shift: 10, copies: 1 })
     end
 
-    it "sets the label length" do
-      label = described_class.new length: 400
-      expect(label.length).to eq 400
-    end
-
-    it "sets the printing speed" do
-      label = described_class.new print_speed: 2
-      expect(label.print_speed).to eq 2
-    end
-
-    it "sets the number of copies" do
-      label = described_class.new copies: 4
-      expect(label.copies).to eq 4
-    end
-
-    it "the number of copies defaults to 1" do
-      label = described_class.new
-      expect(label.copies).to eq 1
+    it "sets attributes" do
+      attributes = { width: 300, length: 400, print_speed: 2, copies: 4, label_shift: 15 }
+      expect(described_class.new(attributes)).to have_attributes(attributes)
     end
 
     it "validates the printing speed" do


### PR DESCRIPTION
Hi there.

Changes:
- Made `^LS` (label shift) command configurable (does not work well on our printer).
- Added `D` font type (spec says that accepted values are A through Z, and 0 to 9, but needed only D).

Thank you.